### PR TITLE
Fix non-persistence of highlights on file reload

### DIFF
--- a/HighlightBuildErrors.py
+++ b/HighlightBuildErrors.py
@@ -96,6 +96,11 @@ class ViewEventListener(sublime_plugin.EventListener):
 
     def on_activated_async(self, view):
         update_errors_in_view(view)
+        
+    def on_modified_async(self, view):
+        if not view.is_dirty():
+            # Then most likely just reloaded or saved!
+            update_errors_in_view(view)
 
     def on_selection_modified(self, view):
         view.erase_status(STATUS_MESSAGE_KEY)

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Erroneous words or lines will be highlighted in the source files.
 * Matthew Twomey
 * Marcin Tolysz
 * Connor Clark
+* [Michael Yoo](https://github.com/sekjun9878) <michael@yoo.id.au>
 
 ## Credits
 


### PR DESCRIPTION
Because Sublime Text 3 doesn't have an event for on_reload, I've used the is_dirty method instead. Normal keystrokes won't trigger this, but on saves or reloads where the file is "not dirty", views will be updated. 

Fixes cases like https://github.com/deadfoxygrandpa/Elm.tmLanguage/issues/95 where if the file is reloaded (e.g. by reformatting) after a build, all the highlights are lost.