### PR TITLE
Configurable popups, fixes #16

### DIFF
--- a/HighlightBuildErrors.py
+++ b/HighlightBuildErrors.py
@@ -72,18 +72,18 @@ def show_error_popup(view):
     if selected_error is None:
         return
 
-    message = split_popup_message(selected_error.message)
+    message_split = split_popup_message(selected_error.message)
 
     if g_settings.get("popup_truncate", True):
-        message = g_settings.get("popup_template", "$1") \
-            .replace("$1", message[0])
+        message_formatted = g_settings.get("popup_template", "$1") \
+            .replace("$1", message_split[0])
     else:
-        message = g_settings.get("popup_template_extended", "$1<br>$2") \
-            .replace("$1", message[0]) \
-            .replace("$2", message[1])
+        message_formatted = g_settings.get("popup_template_extended", "$1<br>$2") \
+            .replace("$1", message_split[0]) \
+            .replace("$2", message_split[1])
 
-    view.set_status(STATUS_MESSAGE_KEY, message)
-    view.show_popup(message, max_width = g_settings.get("popup_max_width", 320), \
+    view.set_status(STATUS_MESSAGE_KEY, message_split[0])
+    view.show_popup(message_formatted, max_width = g_settings.get("popup_max_width", 320), \
                              max_height = g_settings.get("popup_max_height", 240))
 
 def get_selected_error(view):

--- a/HighlightBuildErrors.py
+++ b/HighlightBuildErrors.py
@@ -29,6 +29,7 @@ g_errors = {}
 g_show_errors = True
 g_auto_show_messages = True
 g_color_configs = []
+g_settings = sublime.load_settings(SETTINGS_FILE)
 
 def plugin_loaded():
     settings = sublime.load_settings(SETTINGS_FILE)
@@ -36,9 +37,11 @@ def plugin_loaded():
     load_config()
 
 def load_config():
-    global g_color_configs, g_default_color
-    settings = sublime.load_settings(SETTINGS_FILE)
+    global g_color_configs, g_default_color, g_settings
+
+    g_settings = settings = sublime.load_settings(SETTINGS_FILE)
     g_color_configs = settings.get("colors", [{"color": "sublimelinter.mark.error"}])
+
     for config in g_color_configs:
         if "regex" in config:
             config["compiled_regex"] = re.compile(config["regex"])
@@ -52,12 +55,36 @@ def get_file_name_from_view(view):
         return None
     return normalize_path(file_name)
 
+def split_popup_message(message):
+    # return [first_line, rest]
+    # `rest` maybe an empty string, if `message` is single-line.
+    #
+    # Makes sure that both `first_line` and the `rest` are fully trimmed (no newlines at ends)
+    return list(map(
+        lambda x: x.strip(),
+        (message.strip() + "\n").split('\n', 1)) # Make strip() return list[2] even when no trailing \n
+    )
+
 # displays popup with message for the error the selector is currently on
 def show_error_popup(view):
     selected_error = get_selected_error(view)
-    if selected_error is not None:
-        view.set_status(STATUS_MESSAGE_KEY, selected_error.message)
-        view.show_popup(selected_error.message)
+
+    if selected_error is None:
+        return
+
+    message = split_popup_message(selected_error.message)
+
+    if g_settings.get("popup_truncate", True):
+        message = g_settings.get("popup_template", "$1") \
+            .replace("$1", message[0])
+    else:
+        message = g_settings.get("popup_template_extended", "$1<br>$2") \
+            .replace("$1", message[0]) \
+            .replace("$2", message[1])
+
+    view.set_status(STATUS_MESSAGE_KEY, message)
+    view.show_popup(message, max_width = g_settings.get("popup_max_width", 320), \
+                             max_height = g_settings.get("popup_max_height", 240))
 
 def get_selected_error(view):
     file_name = get_file_name_from_view(view)

--- a/HighlightBuildErrors.sublime-settings
+++ b/HighlightBuildErrors.sublime-settings
@@ -1,23 +1,45 @@
 {
-  // the plugin tests each regex and stops at the first match
-  // "scope" is a key in the .tmTheme file
-  // "display" can be "fill", "outline", "solid_underline", "stippled_underline" or "squiggly_underline"
-  "colors": [
-   {
-      "regex": "note",
-      "icon": "Packages/Highlight Build Errors/information.png"
-    },
-    {
-      "regex": "warning",
-      "scope": "invalid",
-      "display": "outline",
-      "icon": "Packages/Highlight Build Errors/warning.png"
-    },
-    {
-      // default color, when none of the above matches
-      "scope": "invalid",
-      "display": "fill",
-      "icon": "Packages/Highlight Build Errors/error.png"
-    }
-  ]
+    // the plugin tests each regex and stops at the first match
+    // "scope" is a key in the .tmTheme file
+    // "display" can be "fill", "outline", "solid_underline", "stippled_underline" or "squiggly_underline"
+    "colors": [
+        {
+            "regex": "note",
+            "icon": "Packages/Highlight Build Errors/information.png"
+        },
+        {
+            "regex": "warning",
+            "scope": "invalid",
+            "display": "outline",
+            "icon": "Packages/Highlight Build Errors/warning.png"
+        },
+        {
+            // default color, when none of the above matches
+            "scope": "invalid",
+            "display": "fill",
+            "icon": "Packages/Highlight Build Errors/error.png"
+        }
+    ],
+
+    "popup_max_width": 320, // Default Sublime Text 3 API setting
+    "popup_max_height": 240, // Default Sublime Text 3 API setting
+
+    /*
+     * If set to true, will truncate everything after the first newline
+     * and use the setting `popup_template`.
+     *
+     *
+     * If set to false, this will cut the message on the first newline
+     * and store them in different variables ($1 and $2).
+     *
+     * If set to false, will also use `popup_template_extended` instead of
+     * `popup_template`.
+     */
+    "popup_truncate": true,
+
+    // Available variables: $1
+    "popup_template": "$1",
+
+    // Available variables: $1 (first line), $2 (rest)
+    "popup_template_extended": "$1<br>$2",
 }


### PR DESCRIPTION
Hello!

I've implemented a bunch of options to make popups configuable and more user friendly.
This also fixes the issue of popup texts being too cramped when they are long.

I've also changed the indenting of the settings file to four spaces, since that's what all the other plugins seem to use (including ST3 itself).

Please code review and merge. Thanks!